### PR TITLE
Added dynamic task and config registration with `load-grunt-tasks` support.

### DIFF
--- a/templates/tasks/README.md
+++ b/templates/tasks/README.md
@@ -38,6 +38,11 @@ Runs the `buildProd` task (`tasks/register/buildProd.js`).
 
 You can modify, omit, or replace any of these Grunt tasks to fit your requirements. You can also add your own Grunt tasks- just add a `someTask.js` file in the `grunt/config` directory to configure the new task, then register it with the appropriate parent task(s) (see files in `grunt/register/*.js`).
 
+There are two methods that Sails will use to register your Grunt tasks and configuration, either one may be used or mixed to create the build pipeline your application requires:
+
+ 1. The **manual method** is best for highly custom tasks or configuration: it requires each module to export a function which takes a single argument. When Sails encounters this task it will be invoked immediately with the Grunt object.
+ 2. The **dynamic method** only requires an object containing the configuration or an array with the tasks. When Sails encounters this task it will be registered using `grunt.config.set` or `grunt.registerTask` using the filename as the task and the exported object as the parameters.
+
 
 ### Do I have to use Grunt?
 
@@ -51,4 +56,3 @@ That's ok! A core tenant of Sails is client-agnosticism-- it's especially design
 You can completely disable Grunt by following the instructions above.
 
 If you still want to use Grunt for other purposes, but don't want any of the default web front-end stuff, just delete your project's `assets` folder and remove the front-end oriented tasks from the `grunt/register` and `grunt/config` folders.  You can also run `sails new myCoolApi --no-frontend` to omit the `assets` folder and front-end-oriented Grunt tasks for future projects.  You can also replace your `sails-generate-frontend` module with alternative community generators, or create your own.  This allows `sails new` to create the boilerplate for native iOS apps, Android apps, Cordova apps, SteroidsJS apps, etc.
-


### PR DESCRIPTION
This modifies the generated `Gruntfile.js` to include support for dynamically loading configuration and tasks with support of the `load-grunt-tasks` module. This allows for much smaller files in the `tasks/config` and `tasks/register` folders especially for core or contributed Grunt tasks.

For example, the `tasks/config/concat.js` provided by `sails-generate-frontend` can now be written as:

```
module.exports = {
  js: {
    src: require('../pipeline').jsFilesToInject,
    dest: '.tmp/public/concat/production.js'
  },
  css: {
    src: require('../pipeline').cssFilesToInject,
    dest: '.tmp/public/concat/production.css'
  }
};
```

The supporting `grunt-contrib-concat` module is automatically loaded and this configuration is applied. Similarly, task lists can now be exported with just the array containing the tasks. Example `tasks/register/build.js`:

```
module.exports = [
  'compileAssets',
  'linkAssetsBuild',
  'clean:build',
  'copy:build'
];
```

Finally, there is backwards compatibility with the style of the currently generated tasks and configuration. If the module export is detected to be a function, it will be invoked with the `grunt` object as it currently is. This is done not only for backwards compatibility but also in case a custom task needs the entire `grunt` object or a more complex build process is needed. This means that mixing and matching the new dynamic task loading method or the previous more manual method should work as expected.

Let me know if you have any feedback on this approach. If all looks good I plan on making a matching pull request to the `sails-generate-frontend` repo to match!
